### PR TITLE
GH Actions: bust the cache semi-regularly

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           dependency-versions: "${{ inputs.composer-dependencies }}"
           composer-options: "${{ inputs.composer-options }}"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Collect code coverage with Xdebug and phpunit/phpunit"
         env:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           dependency-versions: "${{ inputs.composer-dependencies }}"
           composer-options: "${{ inputs.composer-options }}"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Code style check"
         uses: "phpDocumentor/coding-standard@latest"

--- a/.github/workflows/continues-integration.yml
+++ b/.github/workflows/continues-integration.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           dependency-versions: "${{ inputs.composer-dependencies }}"
           composer-options: "${{ inputs.composer-options }}"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Run tests with phpunit/phpunit"
         run: "vendor/bin/phpunit --colors=always --testsuite=${{ inputs.test-suite }}"

--- a/.github/workflows/dependency-analysis.yml
+++ b/.github/workflows/dependency-analysis.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           dependency-versions: "${{ inputs.composer-dependencies }}"
           composer-options: "${{ inputs.composer-options }}"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Run maglnet/composer-require-checker"
         run: "composer-require-checker check --config-file=$(pwd)/composer-require-checker.json"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           dependency-versions: "${{ inputs.composer-dependencies }}"
           composer-options: "${{ inputs.composer-options }}"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Create cache directory for phpstan/phpstan"
         run: "mkdir -p .build/phpstan"


### PR DESCRIPTION
Caches used in GH Actions do not get updated, they can only be replaced by a different cache with a different cache key.

Now the predefined Composer install action this repo is using already creates a pretty comprehensive cache key:

> `ramsey/composer-install` will auto-generate a cache key which is composed of
the following elements:
> * The OS image name, like `ubuntu-latest`.
> * The exact PHP version, like `8.1.11`.
> * The options passed via `composer-options`.
> * The dependency version setting as per `dependency-versions`.
> * The working directory as per `working-directory`.
> * A hash of the `composer.json` and/or `composer.lock` files.

This means that aside from other factors, the cache will always be busted when changes are made to the (committed) `composer.json` or the `composer.lock` file (if the latter exists in the repo).

For packages running on recent versions of PHP, it also means that the cache will automatically be busted once a month when a new PHP version comes out.

### The problem

For runs on older PHP versions which don't receive updates anymore, the cache will not be busted via new PHP version releases, so effectively, the cache will only be busted when a change is made to the `composer.json`/`composer.lock` file - which may not happen that frequently on low-traffic repos.

But... packages _in use_ on those older PHP versions - especially dependencies of declared dependencies - may still release new versions and those new versions will not exist in the cache and will need to be downloaded each time the action is run and over time the cache gets less and less relevant as more and more packages will need to be downloaded for each run.

### The solution

To combat this issue, a new `custom-cache-suffix` option has been added to the Composer install action in version 2.2.0. This new option allows for providing some extra information to add to the cache key, which allows for busting the cache based on your own additional criteria.

This commit implements the use of this `custom-cache-suffix` option for all relevant workflows in this repo.

Includes updating the `ramsey/composer-install` action to `v2`. (not sure why you were still on v1, but what with `set-output` having been deprecated, you probably want to be on the latest version to prevent future problems)

Refs:
* https://github.com/ramsey/composer-install/#custom-cache-suffix
* https://github.com/ramsey/composer-install/releases/tag/2.2.0