### PR TITLE
Remove platform requirement

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,6 +92,10 @@ jobs:
           echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
         if: "${{ inputs.composer-root-version }}"
 
+      - name: "Remove platform requirement"
+        run: "composer config --unset platform"
+        if: "${{ matrix.dependencies == 'highest' }}"
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:


### PR DESCRIPTION
This requirement might exist to prevent contributors from committing something incompatible with the lowest supported version of PHP to the lock file, thus breaking the "locked" jobs.

Here is a proof that it works: https://github.com/phpDocumentor/guides/actions/runs/7370041293/job/20055989129?pr=793#step:6:105

Note that `composer config --unset platform` is fine to run when when the config option does not exist, so this should not break projects that do not have the option if any.